### PR TITLE
Fixed error message when unable to generate a token

### DIFF
--- a/arcrest/server.py
+++ b/arcrest/server.py
@@ -326,8 +326,8 @@ class GenerateToken(RestURL):
                 pass
             except KeyError:
                 pass
-        raise urllib2.HTTPError("Could not create token using URL {}"
-                                .format(origin_url))
+        raise urllib2.HTTPError(origin_url, 401, "Could not create token using URL {}"
+                                .format(origin_url), None, None)
     @property
     def token(self):
         return self._json_struct['token']


### PR DESCRIPTION
When using any of the command line tools if you specify an invalid server URL, e.g. `-s http://host:6080/arcis` the error message given is:
`Error connecting to REST services http://host:6080/arcis/rest/services/: __init__() takes exactly 6 arguments (2 given)`
Now it the message is:
`Error connecting to REST services http://host:6080/arcis/rest/services/: HTTP Error 401: Could not create token using URL http://host:6080/arcis/rest/services/`
